### PR TITLE
Added distinction between Opera and Opera Mini

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -41,6 +41,7 @@ class Agent extends Mobile_Detect
      * @var array
      */
     protected static $additionalBrowsers = [
+        'Opera Mini' => 'Opera Mini',
         'Opera' => 'Opera|OPR',
         'Edge' => 'Edge',
         'UCBrowser' => 'UCBrowser',
@@ -68,6 +69,7 @@ class Agent extends Mobile_Detect
         'ChromeOS' => 'CrOS x86_64 [VER]',
 
         // Browsers
+        'Opera Mini' => 'Opera Mini/[VER]',
         'Opera' => [' OPR/[VER]', 'Opera Mini/[VER]', 'Version/[VER]', 'Opera [VER]'],
         'Netscape' => 'Netscape/[VER]',
         'Mozilla' => 'rv:[VER]',


### PR DESCRIPTION
Added distinction between Opera  and Opera Mini because even if Opera Mini is an Opera's browser it stays very different from other Opera browsers because it's a proxy browser and it has its own behaviors when rendering web pages or while processing Javascript.

This change will allow to target specifically Opera Mini on mobile without affecting the regular Opera browser.

Referring to the issue [#70](https://github.com/jenssegers/agent/issues/70)